### PR TITLE
add free_obj handler for PHP>=7 to call nn_close

### DIFF
--- a/php_nano_private.h
+++ b/php_nano_private.h
@@ -15,15 +15,15 @@
 |       names of its contributors may be used to endorse or promote products        |
 |       derived from this software without specific prior written permission.       |
 +-----------------------------------------------------------------------------------+
-|  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  | 
-|  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    |   
+|  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND  |
+|  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED    |
 |  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE           |
 |  DISCLAIMED. IN NO EVENT SHALL MIKKO KOPPANEN OR CONTRIBUTORS BE LIABLE FOR       |
-|  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES   |   
+|  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES   |
 |  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;     |
 |  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND      |
 |  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT       |
-|  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    |   
+|  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS    |
 |  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                     |
 +-----------------------------------------------------------------------------------+
 */
@@ -49,11 +49,19 @@ typedef struct {
 /*
   Definition for the socket object
 */
+#if PHP_MAJOR_VERSION >= 7
+typedef struct {
+    int s;
+    HashTable eid;
+    zend_object zo; /* MUST be the last element */
+} php_nano_socket_object;
+#else
 typedef struct {
     zend_object zo;
     int s;
     HashTable eid;
 } php_nano_socket_object;
+#endif
 
 #if ZEND_MODULE_API_NO > 20060613
 


### PR DESCRIPTION
+ correct php_nano_socket_object definition with zend_object at the end
+ little update s_nano_socket_object_new_ex in PHP>=7 case
+ turn off PHP_STREAM_FLAG_NO_CLOSE, anyway what's the reason for it